### PR TITLE
Fix product generation endpoint and update API calls

### DIFF
--- a/server.js
+++ b/server.js
@@ -405,6 +405,22 @@ app.post('/api/process-llm', async (req, res) => {
   }
 });
 
+// Generate product endpoint
+app.post('/api/generate', async (req, res) => {
+  const { prompt } = req.body;
+  try {
+    // Here you would typically call your LLM service
+    // For now, we'll just return a mock response
+    const mockResponse = {
+      response: JSON.stringify(['Sample Product 1', 'Sample Product 2', 'Sample Product 3', 'Sample Product 4', 'Sample Product 5'])
+    };
+    res.json(mockResponse);
+  } catch (error) {
+    console.error('Error generating product:', error);
+    res.status(500).json({ message: 'Error generating product', error: error.message });
+  }
+});
+
 // The "catchall" handler: for any request that doesn't
 // match one above, send back React's index.html file.
 app.get('*', (req, res) => {
@@ -414,4 +430,3 @@ app.get('*', (req, res) => {
 app.listen(port, () => {
   console.log(`Server is running on port ${port}`);
 });
-

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -97,27 +97,12 @@ export const deletePrompt = async (id) => {
 
 export const generateProduct = async (prompt) => {
   try {
-    // First, try the '/api/generate' endpoint
-    try {
-      const response = await api.post('/api/generate', { prompt });
-      console.log("Generate product response:", response.data);
-      if (typeof response.data !== 'object' || !response.data.response) {
-        throw new Error('Received data is not in the expected format');
-      }
-      return response.data;
-    } catch (error) {
-      if (error.response && error.response.status === 404) {
-        // If 404, try the '/api/generate-product' endpoint
-        const fallbackResponse = await api.post('/api/generate-product', { prompt });
-        console.log("Generate product fallback response:", fallbackResponse.data);
-        if (typeof fallbackResponse.data !== 'object' || !fallbackResponse.data.response) {
-          throw new Error('Received data is not in the expected format');
-        }
-        return fallbackResponse.data;
-      } else {
-        throw error;
-      }
+    const response = await api.post('/api/generate', { prompt });
+    console.log("Generate product response:", response.data);
+    if (typeof response.data !== 'object' || !response.data.response) {
+      throw new Error('Received data is not in the expected format');
     }
+    return response.data;
   } catch (error) {
     console.error("Error in generateProduct:", error);
     throw error;


### PR DESCRIPTION
## Summary of changes
This pull request addresses the 404 error encountered during product generation by implementing the following changes:
1. Added a new `/api/generate` endpoint in the server.js file.
2. Updated the `generateProduct` function in the src/utils/api.js file to use the new endpoint.

## Motivation/Context
Users were experiencing a "Failed to generate product: Request failed with status code 404" error when attempting to generate products. This was due to the absence of a proper endpoint on the server to handle product generation requests.

## Implementation details
### server.js
- Added a new `/api/generate` POST endpoint that accepts a prompt and returns a mock response with sample products.
- This endpoint serves as a placeholder for future integration with an actual LLM service.

### src/utils/api.js
- Updated the `generateProduct` function to use the new `/api/generate` endpoint instead of the non-existent `/api/generate-product` endpoint.
- Removed the fallback logic that was attempting to use the `/api/generate-product` endpoint.

## Potential impacts and considerations
- This change resolves the immediate 404 error, allowing users to generate products without encountering an error.
- The current implementation returns mock data. In the future, this endpoint should be connected to an actual LLM service for generating real product data.
- Testing should be performed to ensure that the product generation flow works as expected with these changes.
- The mock data returned by the server should be sufficient for frontend development and testing purposes until the LLM integration is complete.

Please review these changes and provide any feedback or suggestions for improvement.